### PR TITLE
Text Extraction module developed

### DIFF
--- a/OCR_Document_Model/config.yml
+++ b/OCR_Document_Model/config.yml
@@ -1,6 +1,5 @@
 model_ver: 'v0.0.1'
 start_id: 0704.0001
-end_id: 0704.0004 # Due to rounding issues in the 'PDF_Text_Extraction' module, please ensure this max value is 0.0001 less than the max (i.e. if max_value == 0704.0500, then end_id: 0704.0499)
 files_path: 'C:/Sample Data/OCR_arxiv_data'
 extracted_text_path: 'C:/Sample Data/OCR_arxiv_data/Extracted_text'
 extracted_images_path: 'C:/Sample Data/OCR_arxiv_data/Extracted_images'

--- a/OCR_Document_Model/src/PDF_Image_Extraction/PDF_Image_Extraction.py
+++ b/OCR_Document_Model/src/PDF_Image_Extraction/PDF_Image_Extraction.py
@@ -29,5 +29,5 @@ except:
 files_path = global_vars['files_path']
 start_id = global_vars['start_id']
 end_id = global_vars['end_id']
-extracted_images = global_vars['extracted_images_path']
+extracted_images_path = global_vars['extracted_images_path']
 

--- a/OCR_Document_Model/src/PDF_Text_Extraction/PDF_Text_Extraction.py
+++ b/OCR_Document_Model/src/PDF_Text_Extraction/PDF_Text_Extraction.py
@@ -1,5 +1,5 @@
-from os import path, remove
-import json
+from os import listdir
+from os.path import join, splitext
 import fitz # PyMuPDF for PDF and image data extraction
 from pathlib import Path
 import yaml
@@ -27,7 +27,6 @@ except:
 # Load global variables from config YAML file and declare local variables
 files_path = global_vars['files_path']
 start_id = global_vars['start_id']
-end_id = global_vars['end_id']
 extracted_text_path = global_vars['extracted_text_path']
 id = start_id
 
@@ -38,24 +37,19 @@ def extract_text_from_pdf(pdf_path):
     for page_num in range(doc.page_count):
         page = doc[page_num]
         text += page.get_text()
-        
-        # Declare JSON dictionary to store extracted text
-        extracted_text = {
-            'research_text': text
-        }
-
-        with open(Path(extracted_text_path) / 'extracted_text.json', 'a') as f:
-            json.dump(extracted_text, f)
-
+    doc.close()
     return text
 
-# Since the json.dump() call in the loop is an 'append' statement, if the file exists delete it. Otherwise, the json.dump() call will append the dictionary without limit (i.e. objects will duplicate)
-if path.exists(Path(extracted_text_path) / 'extracted_text.json'):
-    remove(Path(extracted_text_path) / 'extracted_text.json')
-
 # Iterate through the list of downloaded PDFs
-with tqdm(total=int((end_id - start_id) / 0.0001) + 1, desc='Text Extraction Progress') as pbar:
-    while id <= end_id:
-        extract_text_from_pdf(f'{files_path}/0{id:.4f}.pdf')
-        id += 0.0001
-        pbar.update(1)
+for pdf_file in tqdm(listdir(files_path), desc='Text PDF Extraction Progress'):
+    try:
+        pdf_text = extract_text_from_pdf(f'{files_path}/0{id:.4f}.pdf')
+    except fitz.fitz.FileNotFoundError: # Handle any FileNotFoundErrors
+        pass
+    else:
+        # Save extracted text to a text file
+        output_text_file = join(extracted_text_path, f'{splitext(pdf_file)[0]}_text.txt')
+        with open(output_text_file, 'w', encoding='utf-8') as text_file:
+            text_file.write(pdf_text)
+
+    id += 0.0001


### PR DESCRIPTION
- Made some significant improvements to the `PDF_Text_Extraction` module to extract and store text into separate txt files
- However, there is a small bug in the code that occurs when a `FileNotFoundError` is raised by the `fitz` library (this occurs when a research paper with a sequential ID number is pulled from arXiv, thereby breaking the sequential ordering of the for loop). Whilst, I've written a `try/except/else` block to handle the errors, it does still have some small issues with the naming and the processing of the files (it appears to skip 1-2 documents) when the code in the `except` block continues processing. Since this is being developed to POC stage only, and this is a relatively minor bug, I'm leaving this bug (but flagging it in this message) without spending too much time trying to repair it.
- Will Commence work on the `PDF_Image_Extraction` module now