### PR TITLE
PyTorch's Learning Rate Finder

### DIFF
--- a/Recommender_Model/src/NCF_Model_Train/NCF_Model_Train.py
+++ b/Recommender_Model/src/NCF_Model_Train/NCF_Model_Train.py
@@ -86,6 +86,8 @@ num_products = sp_matrix.shape[1]
 model = NCF(num_orders, num_products, embedding_dim)
 criterion = nn.MSELoss()
 optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+# IMPORTANT N.B.: CONSIDER USING THE LEARNING RATE FINDER (https://pytorch-lightning.readthedocs.io/en/1.4.9/advanced/lr_finder.html) TO FIND AND PLOT THE MOST OPTIMAL LRs
 # 'step_size' refers to adjusting learning rate by the number of epochs multiplied by 'gamma' (i.e. step_size=2, gamma=0.1 means changing LR every 2 x 0.1 = 0.2 epochs)
 scheduler = StepLR(optimizer, step_size=step_size, gamma=gamma)
 scaler = GradScaler()


### PR DESCRIPTION
- Created a note in the `NCF_Model_Train` module section to investigate modifying the module to use PyTorch's Learning Rate Finder as a means of finding the most optimal LRs (https://pytorch-lightning.readthedocs.io/en/1.4.9/advanced/lr_finder.html). These can be plotted, and suggestions can be made by the algorithm itself. As such, much of the guesswork for determining LRs can be omitted!