### PR TITLE
normalize_image() method rebuilt to address image blackening issue

### DIFF
--- a/OCR_Document_Model/README.md
+++ b/OCR_Document_Model/README.md
@@ -1,4 +1,4 @@
-#  Q&A model based on research papers from arXiv in PDF (WIP)
+#  Optical Character Recognition (OCR) model based on research papers from arXiv in PDF (WIP)
 
 
 # Possible use cases

--- a/OCR_Document_Model/config.yml
+++ b/OCR_Document_Model/config.yml
@@ -5,5 +5,7 @@ files_path: 'C:/Sample Data/OCR_arxiv_data'
 extracted_text_path: 'C:/Sample Data/OCR_arxiv_data/Extracted_text'
 extracted_images_path: 'C:/Sample Data/OCR_arxiv_data/Extracted_images'
 preprocessed_images_path: 'C:/Sample Data/OCR_arxiv_data/Preprocessed_images'
-preprocessed_image_width: 224 #800
-preprocessed_image_height: 224 #600
+preprocessed_image_width: 224 #224
+preprocessed_image_height: 224 #224
+scale_x: 1.2
+scale_y: 1.2


### PR DESCRIPTION
- Rebuilt the `normalize_image()` method to address the issue that caused the images to become completely blackened in the `PDF_Preprocessing` module. The blackening issue is still affecting some images, but for the most part, the new code is a substantial improvement.
- In saying the above, it seems like I might need to rebuild portions of the `PDF_Preprocessing` module over the next several days, as there may be some issues in how I'm performing the preprocessing.