### PR TITLE
Commenced development of RAG Evaluator

### DIFF
--- a/Generative_AI_LLM/HuggingFace_LLM/src/LLM_RAG_Evaluation/LLM_RAG_Evaluation.py
+++ b/Generative_AI_LLM/HuggingFace_LLM/src/LLM_RAG_Evaluation/LLM_RAG_Evaluation.py
@@ -1,0 +1,37 @@
+from langchain_community.llms.huggingface_pipeline import HuggingFacePipeline
+from transformers import AutoTokenizer, GPT2LMHeadModel
+from datasets import Dataset
+import torch
+from pathlib import Path
+import logging
+import yaml
+
+logger = logging.getLogger('LLM_Finetune')
+logger.setLevel(logging.ERROR)
+error_handler = logging.StreamHandler()
+error_handler = logging.FileHandler(Path('C:/Users/Vikram Pande/Side_Projects_(OUTSIDE_REPO)/Error_Logs/LLM_Finetune_log.log'))
+error_handler.setLevel(logging.ERROR)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+error_handler.setFormatter(formatter)
+logger.addHandler(error_handler)
+
+# Load the file paths and global variables from YAML config file
+try:
+    config_path = Path('C:/Users/Vikram Pande/Side_Projects_(OUTSIDE_REPO)/Generative_AI_LLM/HuggingFace_LLM')
+
+    with open(config_path / 'config.yml', 'r') as file:
+        global_vars = yaml.safe_load(file)
+except:
+    logger.error(f'{config_path} YAML Configuration file path not found. Please check the storage path of the \'config.yml\' file and try again')
+
+model_ver = global_vars['model_ver']
+LLM_pretrained_path = global_vars['LLM_pretrained_path']
+pretrained_model = global_vars['pretrained_HG_model']
+
+tokenizer = AutoTokenizer.from_pretrained(pretrained_model)
+model_name = f'C:/Sample Data/Job_Ad_QA_data/saved_models/llm_saved_models/fine_tuned_LLM_{model_ver}'
+tokenizer.save_pretrained(model_name)
+
+hf = HuggingFacePipeline.from_model_id(model_id=model_name,
+                                       task='text-generation',
+                                       device=0)


### PR DESCRIPTION
- Commenced development of a RAG Evaluator under the `LLM_RAG_Evaluation` module
- This is very early in the experimentation & development phase. I'm still early in figuring out how a RAG Evaluator should actually work (ideally including the calculation of benchmark scores, over just relying on RLHF from business stakeholders). As such, this module is highly likely to change as I experiment with and work out how best to build this Evaluator.
- For the moment, it looks like `LangChain` has a great implementation for RAG engines that seems to play nice with the Hugging Face libraries.
- The other thing I want to mention is that in my research so far, I'm seeing the creation of the Retrieval Vector DBs using either OpenAI or some of the other AI companies' servers to host said DB. This incurs financial cost! So, the implementation I'm most trying to achieve is using the local machine. Commercially speaking, we'd be looking to host the Vector Retrieval Document DBs either on prem, or using a clould DB (such as Snowflake, etc.). This would depend on where the business has its existing Data Warehouse.