### PR TITLE
Implemented discrete intervals & MissForest imputation in PreProcessing module

### DIFF
--- a/ECommerce_Churn_Propensity_Model/config.yml
+++ b/ECommerce_Churn_Propensity_Model/config.yml
@@ -2,3 +2,4 @@ model_ver: 0.01
 seed: 314
 content_path: 'C:/Sample Data/Ecommerce_Churn_Data/ECommerce_Dataset.xlsx'
 data_path: 'C:/Sample Data/Ecommerce_Churn_Data'
+utils_path: 'C:/Users/Vikram Pande/Side_Projects_(OUTSIDE_REPO)/ECommerce_Churn_Propensity_Model/src'


### PR DESCRIPTION
- Imputed values using the `MissForest` library (the same as the EDA module)
- Implemented discrete intervals for the 'Tenure' column of the dataset. This was achieved using the `pd.cut()` method.